### PR TITLE
fix broker-list.sh if two or more brokers

### DIFF
--- a/broker-list.sh
+++ b/broker-list.sh
@@ -2,4 +2,4 @@
 
 CONTAINERS=$(docker ps | grep 9092 | awk '{print $1}')
 BROKERS=$(for CONTAINER in ${CONTAINERS}; do docker port "$CONTAINER" 9092 | sed -e "s/0.0.0.0:/$HOST_IP:/g"; done)
-echo "${BROKERS/$'\n'/,}"
+echo "${BROKERS//$'\n'/,}"


### PR DESCRIPTION
According to the official doc below, "If pattern begins with ‘/’, all matches of pattern are replaced with string. Normally only the first match is replaced."

[3.5.3 Shell Parameter Expansion](https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html)